### PR TITLE
Add gitignore and expand KFAC package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/bsde_seed/kfac/__init__.py
+++ b/bsde_seed/kfac/__init__.py
@@ -1,5 +1,6 @@
 """KFAC utilities for physics-informed neural networks."""
 
 from .solver import KFACPINNSolver
+from .optimizer import kfac_update, _init_state
 
-__all__ = ["KFACPINNSolver"]
+__all__ = ["KFACPINNSolver", "kfac_update", "_init_state"]

--- a/bsde_seed/kfac/optimizer.py
+++ b/bsde_seed/kfac/optimizer.py
@@ -1,0 +1,63 @@
+"""Simple KFAC optimizer for PINNs.
+
+This is a minimal implementation that approximates the Fisher
+information matrix using diagonal blocks and performs a natural
+gradient update. It is intentionally lightweight to serve as a
+starting point for a more complete implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+import jax
+import jax.numpy as jnp
+
+
+def _init_state(params: Any) -> Any:
+    """Initialise the running Fisher blocks with zeros matching ``params``."""
+    return jax.tree_util.tree_map(lambda p: jnp.zeros_like(p), params)
+
+
+def kfac_update(
+    params: Any,
+    grads: Any,
+    state: Any,
+    lr: float,
+    decay: float = 0.95,
+    damping: float = 1e-3,
+) -> Tuple[Any, Any]:
+    """Performs a single KFAC-style update.
+
+    Parameters
+    ----------
+    params:
+        Current parameters.
+    grads:
+        Gradients of the loss with respect to ``params``.
+    state:
+        Running estimate of the Fisher information matrix blocks.
+    lr:
+        Learning rate.
+    decay:
+        Exponential decay factor for the running Fisher estimate.
+    damping:
+        Damping added to the Fisher blocks for numerical stability.
+    """
+
+    # Update Fisher blocks
+    new_state = jax.tree_util.tree_map(
+        lambda s, g: decay * s + (1 - decay) * jnp.square(g), state, grads
+    )
+
+    # Compute natural gradient step using diagonal Fisher approximation
+    nat_grads = jax.tree_util.tree_map(
+        lambda g, s: g / (s + damping), grads, new_state
+    )
+
+    new_params = jax.tree_util.tree_map(lambda p, ng: p - lr * ng, params, nat_grads)
+    return new_params, new_state
+
+
+__all__ = ["kfac_update", "_init_state"]
+

--- a/bsde_seed/kfac/solver.py
+++ b/bsde_seed/kfac/solver.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Callable, Iterable, Tuple
+from typing import Callable
 
 import jax
 import jax.numpy as jnp
 import equinox as eqx
+from .optimizer import _init_state, kfac_update
 
 
 class KFACPINNSolver(eqx.Module):
@@ -18,18 +19,19 @@ class KFACPINNSolver(eqx.Module):
     num_steps: int = 100
 
     def run(self, x0: jnp.ndarray, key: jax.random.PRNGKey) -> jnp.ndarray:
-        """Performs a dummy optimization loop using SGD."""
+        """Performs a simple KFAC optimization loop."""
         params, opt_state = eqx.partition(self.net, eqx.is_array)
+        fisher_state = _init_state(params)
 
         @jax.jit
-        def step(params, opt_state, x):
+        def step(params, opt_state, fisher_state, x):
             loss, grads = jax.value_and_grad(self.loss_fn)(eqx.combine(params, opt_state), x)
-            params = jax.tree_util.tree_map(lambda p, g: p - self.lr * g, params, grads)
-            return params, opt_state, loss
+            params, fisher_state = kfac_update(params, grads, fisher_state, self.lr)
+            return params, fisher_state, loss
 
         loss_history = []
         for _ in range(self.num_steps):
-            params, opt_state, loss = step(params, opt_state, x0)
+            params, fisher_state, loss = step(params, opt_state, fisher_state, x0)
             loss_history.append(loss)
         self.net = eqx.combine(params, opt_state)
         return jnp.stack(loss_history)

--- a/notebooks/kfac_pinn_example.ipynb
+++ b/notebooks/kfac_pinn_example.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# KFAC PINN Example",
+    "\n",
+    "This notebook demonstrates the new `KFACPINNSolver` and the simple `kfac_update` routine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax.numpy as jnp\n",
+    "from bsde_seed.kfac import KFACPINNSolver\n",
+    "\n",
+    "# Dummy network and loss function\n",
+    "net = lambda x: x\n",
+    "loss_fn = lambda net, x: jnp.sum(net(x)**2)\n",
+    "\n",
+    "solver = KFACPINNSolver(net=net, loss_fn=loss_fn, num_steps=3)\n",
+    "losses = solver.run(jnp.array([0.0]), jnp.zeros(2, dtype=jnp.uint32))\n",
+    "print(losses)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a repo-level `.gitignore`
- start building KFAC utilities with a diagonal Fisher approximation optimizer
- integrate optimizer into `KFACPINNSolver`
- expose new utilities via the package `__init__`
- provide a simple notebook example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jax')*

------
https://chatgpt.com/codex/tasks/task_e_685727eb03948333820126c6dc1a64a8