### PR TITLE
Add KFAC PINN example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,48 @@
 # DSGE_BSDE
-A self-contained, progressively expanding GitHub repository that teaches the BSDE method for solving continuous-time DSGE models and physics-informed neural networks.
+
+This repository provides a minimal yet extendable code base for experimenting
+with **physics‑informed neural networks (PINNs)** and the
+Kronecker‑Factored Approximate Curvature (KFAC) optimiser.
+It grew out of a teaching project on solving continuous‑time DSGE models with
+backward stochastic differential equations (BSDEs), but the tools here are
+general purpose and can be used for many small‑scale PINN experiments.
+
+The core KFAC implementation lives inside the :mod:`bsde_seed.kfac` package and
+is used throughout the example notebooks.
 
 ## Installation
+
+The project is a normal Python package.  Clone the repository and install it in
+editable mode:
 
 ```bash
 pip install -e .
 ```
 
-Example notebooks can be found in the `notebooks` directory demonstrating the KFAC solver.
+The installation requires a working JAX and Equinox environment.  The
+``pyproject.toml`` lists these dependencies explicitly.
 
-The main optimizer lives in `bsde_seed/bsde_dsgE/optim/kfac.py` and integrates
-with JAX and Equinox modules to support simple PINN training loops.
+## Basic Usage
+
+Once installed you can import the `KFACPINNSolver` from
+`bsde_seed.bsde_dsgE.optim` (or directly from `bsde_seed.kfac`).  A minimal
+training loop only needs a neural network and a loss function::
+
+```python
+import jax.numpy as jnp
+import equinox as eqx
+from bsde_seed.bsde_dsgE.optim import KFACPINNSolver
+
+def residual(net: eqx.Module, x: jnp.ndarray) -> jnp.ndarray:
+    y = net(x)
+    return jnp.mean(y ** 2)
+
+net = eqx.nn.MLP(in_size=1, out_size=1, width_size=8, depth=2, key=jax.random.PRNGKey(0))
+solver = KFACPINNSolver(net=net, loss_fn=residual, num_steps=100)
+losses = solver.run(jnp.zeros((1, 1)), jax.random.PRNGKey(1))
+```
+
+Further tutorials and demonstrations are available in the `notebooks/`
+directory.  The newly added `pinn_kfac_training.ipynb` walks through building a
+simple PINN with JAX/Equinox, optimising it using the KFAC solver and plotting
+its convergence.

--- a/bsde_seed/bsde_dsgE/optim/kfac.py
+++ b/bsde_seed/bsde_dsgE/optim/kfac.py
@@ -1,4 +1,9 @@
-"""Kronecker-Factored Approximate Curvature optimizer utilities."""
+"""Kronecker-Factored Approximate Curvature utilities for PINNs.
+
+This module exposes the same public API as :mod:`bsde_seed.kfac` while keeping a
+simple solver implementation tailored for the teaching examples in this
+repository.
+"""
 
 from __future__ import annotations
 
@@ -8,29 +13,14 @@ import jax
 import jax.numpy as jnp
 import equinox as eqx
 
-
-def init_kfac_state(params: Any) -> Any:
-    """Initialise running estimates for the Fisher information."""
-    return jax.tree_util.tree_map(lambda p: jnp.zeros_like(p), params)
+from bsde_seed.kfac import kfac_update, _init_state
 
 
-def kfac_update(
-    params: Any,
-    grads: Any,
-    state: Any,
-    lr: float,
-    decay: float = 0.95,
-    damping: float = 1e-3,
-) -> Tuple[Any, Any]:
-    """Applies a single KFAC-style update step."""
-    new_state = jax.tree_util.tree_map(
-        lambda s, g: decay * s + (1.0 - decay) * jnp.square(g), state, grads
-    )
-    nat_grads = jax.tree_util.tree_map(
-        lambda g, s: g / (s + damping), grads, new_state
-    )
-    new_params = jax.tree_util.tree_map(lambda p, ng: p - lr * ng, params, nat_grads)
-    return new_params, new_state
+# ---------------------------------------------------------------------------
+# Public functions
+# ---------------------------------------------------------------------------
+
+init_kfac_state = _init_state
 
 
 class KFACPINNSolver(eqx.Module):

--- a/notebooks/pinn_kfac_training.ipynb
+++ b/notebooks/pinn_kfac_training.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PINN Training with KFAC\n",
+    "\n",
+    "This notebook builds a simple PINN using JAX/Equinox and trains it with the `KFACPINNSolver`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import equinox as eqx\n",
+    "import matplotlib.pyplot as plt\n",
+    "from bsde_seed.bsde_dsgE.optim import KFACPINNSolver\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Define a simple PDE: y''(x) + y(x) = 0 with y(0)=0, y(pi)=0 (solution sin(x))\n",
+    "def pinn_loss(net, x):\n",
+    "    def y_fn(x):\n",
+    "        return net(x)[0]\n",
+    "    dy_dx = jax.vmap(jax.grad(y_fn))(x)\n",
+    "    d2y_dx2 = jax.vmap(jax.grad(jax.grad(y_fn)))(x)\n",
+    "    resid = d2y_dx2 + y_fn(x)\n",
+    "    bc = jnp.array([\n",
+    "        y_fn(jnp.array([0.0])),\n",
+    "        y_fn(jnp.array([jnp.pi]))\n",
+    "    ])\n",
+    "    return jnp.mean(resid ** 2) + jnp.mean(bc ** 2)\n",
+    "\n",
+    "key = jax.random.PRNGKey(0)\n",
+    "net = eqx.nn.MLP(in_size=1, out_size=1, width_size=32, depth=2, key=key)\n",
+    "solver = KFACPINNSolver(net=net, loss_fn=pinn_loss, lr=1e-2, num_steps=200)\n",
+    "xs = jnp.linspace(0, jnp.pi, 64).reshape(-1, 1)\n",
+    "losses = solver.run(xs, key)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "plt.plot(losses)\n",
+    "plt.xlabel('step')\n",
+    "plt.ylabel('loss')\n",
+    "plt.title('PINN convergence with KFAC')\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- expand README with project overview and usage instructions
- keep KFAC optimizer API in `bsde_seed.bsde_dsgE.optim` but reuse implementation
- add `pinn_kfac_training.ipynb` demo notebook showing a simple PINN solved with KFAC

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572d5a00c48333a14c489cf2e1961c