### PR TITLE
Add tests for KFAC optimizer and Lucas model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+bsde_seed.egg-info/

--- a/bsde_seed/tests/test_kfac_toy_pde.py
+++ b/bsde_seed/tests/test_kfac_toy_pde.py
@@ -1,0 +1,24 @@
+import jax
+import jax.numpy as jnp
+import equinox as eqx
+
+from bsde_seed.bsde_dsgE.optim import KFACPINNSolver
+
+
+def pde_residual(net: eqx.Module, x: jnp.ndarray) -> jnp.ndarray:
+    """Residual for y'(x) = 1 with unknown constant."""
+    # net maps x -> y(x)
+    def single_output(x_scalar):
+        return net(jnp.array([x_scalar]))[0]
+
+    dydx = jax.vmap(jax.grad(single_output))(x[:, 0])
+    return jnp.mean((dydx - 1.0) ** 2)
+
+
+def test_kfac_optimizer_toy_pde():
+    key = jax.random.PRNGKey(0)
+    net = eqx.nn.MLP(in_size=1, out_size=1, width_size=8, depth=2, key=key)
+    solver = KFACPINNSolver(net=net, loss_fn=pde_residual, lr=1e-2, num_steps=50)
+    x = jnp.linspace(0.0, 1.0, num=5).reshape(-1, 1)
+    losses = solver.run(x, key)
+    assert losses[-1] < losses[0]

--- a/bsde_seed/tests/test_scalar_lucas.py
+++ b/bsde_seed/tests/test_scalar_lucas.py
@@ -1,0 +1,13 @@
+import jax.numpy as jnp
+from bsde_seed.bsde_dsgE.models import scalar_lucas
+
+
+def test_scalar_lucas_gbm_drift_diffusion():
+    mu = 0.1
+    sigma = 0.3
+    drift, diffusion, _, _ = scalar_lucas(mu=mu, sigma=sigma)
+    x = jnp.array([1.0, 2.0, 3.0])
+    expected_drift = mu * x
+    expected_diff = sigma * x
+    assert jnp.allclose(drift(x), expected_drift)
+    assert jnp.allclose(diffusion(x), expected_diff)


### PR DESCRIPTION
## Summary
- ignore `bsde_seed.egg-info` from version control
- add test for KFAC solver on a toy PDE residual
- add test for Lucas model drift/diffusion functions

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685733aad7b08333846a7a39b6a3dd10