### PR TITLE
Improve KFAC documentation

### DIFF
--- a/bsde_dsgE/kfac/__init__.py
+++ b/bsde_dsgE/kfac/__init__.py
@@ -1,6 +1,6 @@
 """KFAC utilities for physics-informed neural networks."""
 
+from .optimizer import kfac_update
 from .solver import KFACPINNSolver
-from .optimizer import kfac_update, _init_state
 
-__all__ = ["KFACPINNSolver", "kfac_update", "_init_state"]
+__all__ = ["KFACPINNSolver", "kfac_update"]

--- a/bsde_dsgE/kfac/optimizer.py
+++ b/bsde_dsgE/kfac/optimizer.py
@@ -1,9 +1,23 @@
-"""Simple KFAC optimizer for PINNs.
+"""Lightweight Kronecker-Factored Approximate Curvature utilities.
 
-This is a minimal implementation that approximates the Fisher
-information matrix using diagonal blocks and performs a natural
-gradient update. It is intentionally lightweight to serve as a
-starting point for a more complete implementation.
+This module implements a minimal KFAC update suitable for
+Physics-informed neural networks (PINNs). The Fisher information matrix
+is approximated using diagonal blocks, resulting in a natural gradient
+step that can be executed efficiently with :mod:`jax`.
+
+Examples
+--------
+>>> import jax
+>>> import jax.numpy as jnp
+>>> from bsde_dsgE.kfac import kfac_update, _init_state
+
+Create a simple parameter tree and corresponding gradients
+>>> params = {"w": jnp.ones((2, 2))}
+>>> grads = jax.tree_util.tree_map(lambda p: 0.1 * jnp.ones_like(p), params)
+>>> state = _init_state(params)
+
+Update the parameters using a single KFAC step
+>>> new_params, state = kfac_update(params, grads, state, lr=0.01)
 """
 
 from __future__ import annotations
@@ -15,7 +29,27 @@ import jax.numpy as jnp
 
 
 def _init_state(params: Any) -> Any:
-    """Initialise the running Fisher blocks with zeros matching ``params``."""
+    """Create an initial KFAC state.
+
+    Parameters
+    ----------
+    params : Any
+        PyTree of parameters whose structure and shapes will be mirrored in
+        the returned state.
+
+    Returns
+    -------
+    Any
+        A PyTree of zeros with the same structure as ``params``.
+
+    Examples
+    --------
+    >>> params = {"w": jnp.ones((2, 2))}
+    >>> state = _init_state(params)
+    >>> jax.tree_util.tree_map(jnp.shape, state)
+    {'w': (2, 2)}
+    """
+
     return jax.tree_util.tree_map(lambda p: jnp.zeros_like(p), params)
 
 
@@ -27,22 +61,34 @@ def kfac_update(
     decay: float = 0.95,
     damping: float = 1e-3,
 ) -> Tuple[Any, Any]:
-    """Performs a single KFAC-style update.
+    """Perform a single KFAC update step.
 
     Parameters
     ----------
-    params:
-        Current parameters.
-    grads:
+    params : Any
+        Current model parameters.
+    grads : Any
         Gradients of the loss with respect to ``params``.
-    state:
-        Running estimate of the Fisher information matrix blocks.
-    lr:
-        Learning rate.
-    decay:
+    state : Any
+        Running estimate of the diagonal Fisher information blocks.
+    lr : float
+        Learning rate used for the natural gradient step.
+    decay : float, default=0.95
         Exponential decay factor for the running Fisher estimate.
-    damping:
-        Damping added to the Fisher blocks for numerical stability.
+    damping : float, default=1e-3
+        Small value added to the Fisher blocks for numerical stability.
+
+    Returns
+    -------
+    Tuple[Any, Any]
+        The updated ``params`` and Fisher state.
+
+    Examples
+    --------
+    >>> params = {"w": jnp.ones((2, 2))}
+    >>> grads = {"w": jnp.full((2, 2), 0.1)}
+    >>> state = _init_state(params)
+    >>> new_params, state = kfac_update(params, grads, state, lr=0.01)
     """
 
     # Update Fisher blocks
@@ -59,5 +105,5 @@ def kfac_update(
     return new_params, new_state
 
 
-__all__ = ["kfac_update", "_init_state"]
+__all__ = ["kfac_update"]
 


### PR DESCRIPTION
## Summary
- add usage examples and detailed docstrings to the KFAC optimizer
- expand the solver documentation
- mark only public functions in `__all__`

## Testing
- `ruff check bsde_dsgE/kfac/optimizer.py bsde_dsgE/kfac/solver.py bsde_dsgE/kfac/__init__.py --select E,F,I,B`
- `mypy bsde_dsgE/kfac/optimizer.py bsde_dsgE/kfac/solver.py bsde_dsgE/kfac/__init__.py --strict`

------
https://chatgpt.com/codex/tasks/task_e_685747703eb08333988551ed6ebaa00a