### PR TITLE
Add root exports for KFAC utilities

### DIFF
--- a/bsde_dsgE/__init__.py
+++ b/bsde_dsgE/__init__.py
@@ -1,0 +1,17 @@
+"""Convenience imports for the :mod:`bsde_dsgE` package.
+
+This module re-exports the key KFAC optimisation utilities and solver
+constructors used throughout the repository.
+"""
+
+from .kfac import kfac_update, KFACPINNSolver as KFACPINNSolverFull
+from .optim import init_kfac_state, KFACPINNSolver
+from .core.init import load_solver
+
+__all__ = [
+    "kfac_update",
+    "KFACPINNSolverFull",
+    "init_kfac_state",
+    "KFACPINNSolver",
+    "load_solver",
+]


### PR DESCRIPTION
## Summary
- expose `kfac_update`, `init_kfac_state`, and related solvers at the package root
- re-export optional `load_solver`

## Testing
- `ruff check bsde_dsgE/__init__.py`
- `black bsde_dsgE/__init__.py`
- `mypy bsde_dsgE/__init__.py`
- `pytest -q` *(fails: test_kfac_optimizer_toy_pde)*

------
https://chatgpt.com/codex/tasks/task_e_68574ba496788333aeaa7d25ff34c4b6