### PR TITLE
Add KFAC PINN utilities and remove unused models

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,6 @@ pytest -q                     # 30 s smoke‑tests
 iteration calls `kfac_update` to apply a diagonal K‑FAC natural
 gradient step. See
 [`kfac_pinn_example.ipynb`](notebooks/kfac_pinn_example.ipynb) for a
-minimal demonstration.
+minimal demonstration. A shorter
+[`kfac_pinn_quickstart.ipynb`](notebooks/kfac_pinn_quickstart.ipynb)
+shows the basic training loop on a 1D Poisson problem.

--- a/bsde_dsgE/kfac/__init__.py
+++ b/bsde_dsgE/kfac/__init__.py
@@ -1,6 +1,18 @@
-"""KFAC utilities for physics-informed neural networks."""
+"""KFAC utilities for physics-informed neural networks.
+
+This subpackage implements a lightweight Kronecker-Factored Approximate
+Curvature update along with a simple training loop for PINNs.  Additional
+helpers for common PDEs are provided for convenience.
+"""
 
 from .optimizer import kfac_update, _init_state
 from .solver import KFACPINNSolver
+from .pde import poisson_1d_residual, pinn_loss
 
-__all__ = ["KFACPINNSolver", "kfac_update", "_init_state"]
+__all__ = [
+    "KFACPINNSolver",
+    "kfac_update",
+    "_init_state",
+    "poisson_1d_residual",
+    "pinn_loss",
+]

--- a/bsde_dsgE/kfac/pde.py
+++ b/bsde_dsgE/kfac/pde.py
@@ -1,0 +1,46 @@
+"""PDE utilities for PINNs.
+
+This module provides helper functions to compute residuals for simple
+partial differential equations. They are intended for small examples in
+conjunction with :class:`~bsde_dsgE.kfac.KFACPINNSolver`.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import jax
+import jax.numpy as jnp
+
+__all__ = ["poisson_1d_residual", "pinn_loss"]
+
+
+def poisson_1d_residual(net: Callable[[jnp.ndarray], jnp.ndarray], x: jnp.ndarray, f: Callable[[jnp.ndarray], jnp.ndarray] | None = None) -> jnp.ndarray:
+    """Compute the residual of ``u''(x) = f(x)`` with zero boundary conditions.
+
+    Parameters
+    ----------
+    net:
+        Callable neural network approximating ``u(x)``.
+    x:
+        Interior points where the residual is evaluated.
+    f:
+        Right hand side function ``f(x)``. Defaults to zero.
+    """
+    if f is None:
+        f = lambda x: jnp.zeros_like(x)
+
+    d2u_dx2 = jax.vmap(jax.grad(jax.grad(net)))(x)
+    return d2u_dx2 - f(x)
+
+
+def pinn_loss(
+    net: Callable[[jnp.ndarray], jnp.ndarray],
+    interior_x: jnp.ndarray,
+    bc_x: jnp.ndarray,
+    f: Callable[[jnp.ndarray], jnp.ndarray] | None = None,
+) -> jnp.ndarray:
+    """Return the squared residual loss for the Poisson problem."""
+    res = poisson_1d_residual(net, interior_x, f)
+    bc_res = net(bc_x)
+    return jnp.mean(res ** 2) + jnp.mean(bc_res ** 2)

--- a/bsde_dsgE/models/two_agent.py
+++ b/bsde_dsgE/models/two_agent.py
@@ -1,1 +1,0 @@
-# (CRRA, fixed weights)

--- a/bsde_dsgE/models/two_tree.py
+++ b/bsde_dsgE/models/two_tree.py
@@ -1,1 +1,0 @@
-      # (EZ, endogenous r, κ)

--- a/notebooks/kfac_pinn_quickstart.ipynb
+++ b/notebooks/kfac_pinn_quickstart.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Quickstart: KFAC for PINNs\n",
+    "This notebook demonstrates how to solve a 1D Poisson equation using `KFACPINNSolver`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import jax, jax.numpy as jnp\n",
+    "import equinox as eqx\n",
+    "from bsde_dsgE.kfac import KFACPINNSolver, pinn_loss\n",
+    "\n",
+    "net = eqx.nn.MLP(in_size=1, out_size=1, width_size=16, depth=2, key=jax.random.PRNGKey(0))\n",
+    "def loss_fn(net, x):\n",
+    "    interior = x\n",
+    "    bc = jnp.array([0.0, 1.0])\n",
+    "    return pinn_loss(lambda z: net(z).squeeze(), interior, bc)\n",
+    "\n",
+    "solver = KFACPINNSolver(net=net, loss_fn=loss_fn, lr=1e-2, num_steps=10)\n",
+    "xs = jnp.linspace(0.0, 1.0, 16).reshape(-1, 1)\n",
+    "losses = solver.run(xs, jax.random.PRNGKey(1))\n",
+    "print('final loss', float(losses[-1]))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_pde.py
+++ b/tests/test_pde.py
@@ -1,0 +1,17 @@
+import jax.numpy as jnp
+from bsde_dsgE.kfac.pde import poisson_1d_residual, pinn_loss
+
+
+def test_poisson_zero_residual():
+    net = lambda x: jnp.zeros_like(x)
+    x = jnp.linspace(0.0, 1.0, 4)
+    res = poisson_1d_residual(net, x)
+    assert jnp.allclose(res, 0)
+
+
+def test_pinn_loss_zero_solution():
+    net = lambda x: jnp.zeros_like(x)
+    interior = jnp.linspace(0.0, 1.0, 4)
+    bc = jnp.array([0.0, 1.0])
+    loss = pinn_loss(net, interior, bc)
+    assert loss == 0


### PR DESCRIPTION
## Summary
- drop empty `two_agent` and `two_tree` model modules
- expose new Poisson helpers in `bsde_dsgE.kfac`
- create `pde.py` with Poisson residual utilities
- add quickstart notebook for KFAC PINN
- mention quickstart notebook in README
- test PDE helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bsde_dsgE')*

------
https://chatgpt.com/codex/tasks/task_e_68575374553c83339a538d1fab2f8ff5