### PR TITLE
[M-03] Sobol grids & Pareto root-finding

### DIFF
--- a/bsde_dsgE/core/grids.py
+++ b/bsde_dsgE/core/grids.py
@@ -1,1 +1,59 @@
-# (Sobol Brownian, adaptive dt)
+"""Utilities for Brownian path generation."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import jax.numpy as jnp
+from scipy import stats  # type: ignore
+from scipy.stats import qmc  # type: ignore
+
+__all__ = ["sobol_brownian"]
+
+
+def sobol_brownian(
+    *,
+    steps: int,
+    batch: int,
+    dt: float | Sequence[float],
+    dim: int = 1,
+) -> jnp.ndarray:
+    """Sobol quasi-random Brownian increments.
+
+    Parameters
+    ----------
+    steps : int
+        Number of time steps in the Brownian path.
+    batch : int
+        Number of independent paths to generate. Must be even to enable
+        antithetic pairing.
+    dt : float or sequence of float
+        Fixed time step or array of varying step sizes of length ``steps``.
+    dim : int, default=1
+        Dimension of the Brownian motion.
+
+    Returns
+    -------
+    jnp.ndarray
+        Array of shape ``(batch, steps, dim)`` containing Brownian
+        increments scaled by ``sqrt(dt)``.
+    """
+
+    if batch % 2 != 0:
+        raise ValueError("batch must be even for antithetic pairing")
+
+    engine = qmc.Sobol(d=dim * steps, scramble=False)
+    sob = engine.random(batch // 2)
+    sob = jnp.clip(jnp.asarray(sob), 1e-6, 1 - 1e-6)
+    g = stats.norm.ppf(sob)
+    g = jnp.concatenate([g, -g], axis=0).reshape(batch, steps, dim)
+
+    dt_arr = jnp.asarray(dt)
+    if dt_arr.ndim == 0:
+        scale = jnp.sqrt(dt_arr)
+    elif dt_arr.shape == (steps,):
+        scale = jnp.sqrt(dt_arr)[:, None]
+    else:
+        raise ValueError("dt must be a scalar or a sequence of length `steps`")
+
+    return g * scale

--- a/bsde_dsgE/core/outer_loop.py
+++ b/bsde_dsgE/core/outer_loop.py
@@ -1,1 +1,53 @@
-# (Pareto bisection, root‑find)
+"""Pareto weight search via bisection."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import jax
+import jax.numpy as jnp
+
+__all__ = ["pareto_bisection"]
+
+
+def pareto_bisection(
+    f: Callable[[float], float],
+    lo: float,
+    hi: float,
+    *,
+    tol: float = 1e-6,
+    max_iter: int = 50,
+) -> float:
+    """Find a root of ``f`` using the bisection method.
+
+    Parameters
+    ----------
+    f : Callable[[float], float]
+        Monotonic function whose root is sought.
+    lo, hi : float
+        Bracketing interval with ``f(lo)`` and ``f(hi)`` of opposite sign.
+    tol : float, default=1e-6
+        Termination tolerance for the interval width.
+    max_iter : int, default=50
+        Maximum number of iterations.
+
+    Returns
+    -------
+    float
+        Approximate root of ``f``.
+    """
+
+    def body(state):
+        lo, hi, it = state
+        mid = 0.5 * (lo + hi)
+        val = f(mid)
+        lo = jnp.where(val > 0, lo, mid)
+        hi = jnp.where(val > 0, mid, hi)
+        return lo, hi, it + 1
+
+    def cond(state):
+        lo, hi, it = state
+        return (it < max_iter) & (hi - lo > tol)
+
+    lo, hi, _ = jax.lax.while_loop(cond, body, (lo, hi, 0))
+    return float(0.5 * (lo + hi))

--- a/notebooks/sobol_pareto_demo.ipynb
+++ b/notebooks/sobol_pareto_demo.ipynb
@@ -1,0 +1,10 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "metadata": {}, "source": ["# Sobol and Pareto Demo\n", "Demonstrate new utilities from `bsde_dsgE.core`."]},
+  {"cell_type": "code", "metadata": {}, "source": ["from bsde_dsgE.core.grids import sobol_brownian\n", "import jax.numpy as jnp\n", "paths = sobol_brownian(steps=4, batch=8, dt=0.1)\n", "print(paths.shape)"]},
+  {"cell_type": "code", "metadata": {}, "source": ["from bsde_dsgE.core.outer_loop import pareto_bisection\n", "root = pareto_bisection(lambda x: x**2 - 2, 0.0, 2.0)\n", "print(float(root))"]}
+ ],
+ "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python"}},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,0 +1,16 @@
+import jax.numpy as jnp
+from bsde_dsgE.core.grids import sobol_brownian
+
+
+def test_sobol_brownian_shape():
+    out = sobol_brownian(steps=3, batch=8, dt=0.1)
+    assert out.shape == (8, 3, 1)
+
+
+def test_sobol_brownian_stats():
+    dt = 0.1
+    out = sobol_brownian(steps=50, batch=1000, dt=dt)
+    mean = jnp.mean(out)
+    var = jnp.var(out)
+    assert jnp.allclose(mean, 0.0, atol=5e-2)
+    assert jnp.allclose(var, dt, atol=5e-2)

--- a/tests/test_outer_loop.py
+++ b/tests/test_outer_loop.py
@@ -1,0 +1,10 @@
+import jax.numpy as jnp
+from bsde_dsgE.core.outer_loop import pareto_bisection
+
+
+def test_pareto_bisection():
+    def f(x: float) -> float:
+        return x**2 - 2.0
+
+    root = pareto_bisection(f, 0.0, 2.0, tol=1e-6)
+    assert jnp.allclose(root, jnp.sqrt(2.0), atol=1e-5)


### PR DESCRIPTION
## Summary
- implement Sobol-based Brownian generator
- implement Pareto root finder
- add unit tests for new utilities
- include demo notebook showing usage

## Testing
- `ruff check bsde_dsgE/core/grids.py bsde_dsgE/core/outer_loop.py tests/test_grids.py tests/test_outer_loop.py`
- `black bsde_dsgE/core/grids.py tests/test_grids.py tests/test_outer_loop.py bsde_dsgE/core/outer_loop.py`
- `mypy bsde_dsgE/core/grids.py bsde_dsgE/core/outer_loop.py tests/test_grids.py tests/test_outer_loop.py`
- `pytest -q`
- `pre-commit run --files bsde_dsgE/core/grids.py bsde_dsgE/core/outer_loop.py tests/test_grids.py tests/test_outer_loop.py notebooks/sobol_pareto_demo.ipynb` *(fails: ruff/mypy config)*

------
https://chatgpt.com/codex/tasks/task_e_6857641d22108333b1a6e9b72da5581a