### PR TITLE
Fix CI jax deps

### DIFF
--- a/ci/lint_test.yml
+++ b/ci/lint_test.yml
@@ -7,6 +7,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with: {python-version: '3.11'}
+    - run: pip install jax jaxlib
     - run: pip install .[dev]
     - run: ruff check .
     - run: mypy bsde_dsgE


### PR DESCRIPTION
## Summary
- ensure CPU jax wheels are installed during CI

## Testing
- `ruff check .`
- `mypy bsde_dsgE` *(fails: Module has no attribute "sobol_sample", etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685767c4d9f08333995a58002d01cd5f