### PR TITLE
Use scipy Sobol for Brownian helper

### DIFF
--- a/bsde_dsgE/utils/sde_tools.py
+++ b/bsde_dsgE/utils/sde_tools.py
@@ -3,16 +3,36 @@
 Small helpers: Ito's lemma, jacobians, Sobol Brownian generator.
 """
 
-from typing import Tuple
+from typing import Sequence
 
 import jax
 import jax.numpy as jnp
+from scipy import stats  # type: ignore
+from scipy.stats import qmc  # type: ignore
 
 
-def sobol_brownian(dim: int, steps: int, batch: int, dt: float) -> jax.Array:
+def sobol_brownian(
+    dim: int,
+    steps: int,
+    batch: int,
+    dt: float | Sequence[float],
+) -> jax.Array:
     """Sobol quasi-random Brownian paths with antithetic pairing."""
-    sob = jax.random.sobol_sample(steps * dim, batch // 2)  # type: ignore[attr-defined]
-    sob = jnp.clip(sob, 1e-6, 1 - 1e-6)
-    g = jax.scipy.stats.norm.ppf(sob)
-    g = jnp.concatenate([g, -g], 0).reshape(batch, steps, dim)
-    return g * jnp.sqrt(dt)
+    if batch % 2 != 0:
+        raise ValueError("batch must be even for antithetic pairing")
+
+    engine = qmc.Sobol(d=dim * steps, scramble=False)
+    sob = engine.random(batch // 2)
+    sob = jnp.clip(jnp.asarray(sob), 1e-6, 1 - 1e-6)
+    g = jnp.asarray(stats.norm.ppf(sob))
+    g = jnp.concatenate([g, -g], axis=0).reshape(batch, steps, dim)
+
+    dt_arr = jnp.asarray(dt)
+    if dt_arr.ndim == 0:
+        scale = jnp.sqrt(dt_arr)
+    elif dt_arr.shape == (steps,):
+        scale = jnp.sqrt(dt_arr)[:, None]
+    else:
+        raise ValueError("dt must be a scalar or a sequence of length `steps`")
+
+    return g * scale

--- a/tests/test_sde_tools.py
+++ b/tests/test_sde_tools.py
@@ -1,0 +1,16 @@
+import jax.numpy as jnp
+from bsde_dsgE.utils.sde_tools import sobol_brownian
+
+
+def test_sobol_brownian_shape():
+    out = sobol_brownian(dim=1, steps=3, batch=8, dt=0.1)
+    assert out.shape == (8, 3, 1)
+
+
+def test_sobol_brownian_stats():
+    dt = 0.1
+    out = sobol_brownian(dim=1, steps=50, batch=1000, dt=dt)
+    mean = jnp.mean(out)
+    var = jnp.var(out)
+    assert jnp.allclose(mean, 0.0, atol=5e-2)
+    assert jnp.allclose(var, dt, atol=5e-2)


### PR DESCRIPTION
## Summary
- reimplement `sobol_brownian` in `sde_tools` with `scipy.stats.qmc.Sobol`
- add unit tests for `sde_tools.sobol_brownian`

## Testing
- `ruff check bsde_dsgE tests`
- `mypy bsde_dsgE`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857781818bc833399ec0904d094e5db