### PR TITLE
Use eqx.filter_jit in solver

### DIFF
--- a/bsde_dsgE/kfac/solver.py
+++ b/bsde_dsgE/kfac/solver.py
@@ -77,7 +77,7 @@ class KFACPINNSolver(eqx.Module):
         params, static = eqx.partition(self.net, eqx.is_array)
         fisher_state = _init_state(params)
 
-        @jax.jit
+        @eqx.filter_jit
         def step(
             params: Any,
             fisher_state: Any,


### PR DESCRIPTION
## Summary
- use `eqx.filter_jit` instead of `jax.jit` when running KFAC solver steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685781cf75988333a6d8de9285cfb0d4