### PR TITLE
Refactor Sobol brownian import

### DIFF
--- a/bsde_dsgE/core/grids.py
+++ b/bsde_dsgE/core/grids.py
@@ -2,59 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Sequence
-
-import jax
-import jax.numpy as jnp
-from scipy import stats  # type: ignore
-from scipy.stats import qmc  # type: ignore
+from bsde_dsgE.utils.sde_tools import sobol_brownian
 
 __all__ = ["sobol_brownian"]
-
-
-def sobol_brownian(
-    *,
-    steps: int,
-    batch: int,
-    dt: float | Sequence[float],
-    dim: int = 1,
-) -> jax.Array:
-    """Sobol quasi-random Brownian increments.
-
-    Parameters
-    ----------
-    steps : int
-        Number of time steps in the Brownian path.
-    batch : int
-        Number of independent paths to generate. Must be even to enable
-        antithetic pairing.
-    dt : float or sequence of float
-        Fixed time step or array of varying step sizes of length ``steps``.
-    dim : int, default=1
-        Dimension of the Brownian motion.
-
-    Returns
-    -------
-    jnp.ndarray
-        Array of shape ``(batch, steps, dim)`` containing Brownian
-        increments scaled by ``sqrt(dt)``.
-    """
-
-    if batch % 2 != 0:
-        raise ValueError("batch must be even for antithetic pairing")
-
-    engine = qmc.Sobol(d=dim * steps, scramble=False)
-    sob = engine.random(batch // 2)
-    sob = jnp.clip(jnp.asarray(sob), 1e-6, 1 - 1e-6)
-    g = jnp.asarray(stats.norm.ppf(sob))
-    g = jnp.concatenate([g, -g], axis=0).reshape(batch, steps, dim)
-
-    dt_arr = jnp.asarray(dt)
-    if dt_arr.ndim == 0:
-        scale = jnp.sqrt(dt_arr)
-    elif dt_arr.shape == (steps,):
-        scale = jnp.sqrt(dt_arr)[:, None]
-    else:
-        raise ValueError("dt must be a scalar or a sequence of length `steps`")
-
-    return g * scale

--- a/notebooks/sobol_pareto_demo.ipynb
+++ b/notebooks/sobol_pareto_demo.ipynb
@@ -1,10 +1,43 @@
 {
- "cells": [
-  {"cell_type": "markdown", "metadata": {}, "source": ["# Sobol and Pareto Demo\n", "Demonstrate new utilities from `bsde_dsgE.core`."]},
-  {"cell_type": "code", "metadata": {}, "source": ["from bsde_dsgE.core.grids import sobol_brownian\n", "import jax.numpy as jnp\n", "paths = sobol_brownian(steps=4, batch=8, dt=0.1)\n", "print(paths.shape)"]},
-  {"cell_type": "code", "metadata": {}, "source": ["from bsde_dsgE.core.outer_loop import pareto_bisection\n", "root = pareto_bisection(lambda x: x**2 - 2, 0.0, 2.0)\n", "print(float(root))"]}
- ],
- "metadata": {"kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}, "language_info": {"name": "python"}},
- "nbformat": 4,
- "nbformat_minor": 5
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Sobol and Pareto Demo\n",
+        "Demonstrate new utilities from `bsde_dsgE.core`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from bsde_dsgE.utils.sde_tools import sobol_brownian\n",
+        "import jax.numpy as jnp\n",
+        "paths = sobol_brownian(steps=4, batch=8, dt=0.1)\n",
+        "print(paths.shape)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from bsde_dsgE.core.outer_loop import pareto_bisection\n",
+        "root = pareto_bisection(lambda x: x**2 - 2, 0.0, 2.0)\n",
+        "print(float(root))"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/tests/test_grids.py
+++ b/tests/test_grids.py
@@ -1,15 +1,15 @@
 import jax.numpy as jnp
-from bsde_dsgE.core.grids import sobol_brownian
+from bsde_dsgE.utils.sde_tools import sobol_brownian
 
 
 def test_sobol_brownian_shape():
-    out = sobol_brownian(steps=3, batch=8, dt=0.1)
+    out = sobol_brownian(dim=1, steps=3, batch=8, dt=0.1)
     assert out.shape == (8, 3, 1)
 
 
 def test_sobol_brownian_stats():
     dt = 0.1
-    out = sobol_brownian(steps=50, batch=1000, dt=dt)
+    out = sobol_brownian(dim=1, steps=50, batch=1000, dt=dt)
     mean = jnp.mean(out)
     var = jnp.var(out)
     assert jnp.allclose(mean, 0.0, atol=5e-2)


### PR DESCRIPTION
## Summary
- centralize `sobol_brownian` in `bsde_dsgE.utils.sde_tools`
- re-export from `bsde_dsgE.core.grids`
- update tests and notebook imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685784baa824833397a0df4ee8478745