### PR TITLE
Add grid-search CLI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ examples:
   – using the `bsde_dsgE.kfac` package
 * [`pinn_kfac_quickstart_pkg.ipynb`](notebooks/pinn_kfac_quickstart_pkg.ipynb)
   – integrated module
+* [`grid_search.py`](examples/grid_search.py) – sweep risk aversion values
 
 See the generated documentation in [`docs/`](docs/) for a rendered version of
 these tutorials.

--- a/examples/grid_search.py
+++ b/examples/grid_search.py
@@ -1,20 +1,58 @@
+"""Minimal grid‑search over the Lucas economy parameters.
+
+This script sweeps the risk‑aversion coefficient ``gamma`` across a list of
+values and records the terminal PDE residual for each model.  The results are
+saved as a JSON file and can be visualised with ``dvc plots`` or other tooling.
+
+Running the example prints a dictionary ``{gamma: residual}`` and writes the
+same mapping to ``<output>/grid.json``.
 """
-Grid‑search over risk‑aversion {5,7,9}.  Saves each PDE residual
-to `dvc plots`.
-"""
-import itertools, json, pathlib, jax, jax.numpy as jnp
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+
+import jax
+import jax.numpy as jnp
 from bsde_dsgE.core import load_solver
 from bsde_dsgE.models import ct_lucas
 
 
-out = {}
-for gamma in [5.0, 7.0, 9.0]:
-    model = ct_lucas.scalar_lucas(gamma=gamma)
-    solver = load_solver(model, dt=0.1)
-    key = jax.random.PRNGKey(1)
-    loss = solver(jnp.ones((64,)) * 0.8, key)
-    out[gamma] = float(loss)
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Lucas model grid search")
+    parser.add_argument(
+        "--gammas",
+        type=str,
+        default="5,7,9",
+        help="Comma separated list of risk aversion values",
+    )
+    parser.add_argument(
+        "--output",
+        type=pathlib.Path,
+        default=pathlib.Path("artifacts"),
+        help="Directory to store the grid-search results",
+    )
+    return parser.parse_args()
 
-pathlib.Path("artifacts").mkdir(exist_ok=True)
-json.dump(out, open("artifacts/grid.json", "w"))
-print("grid‑search results", out)
+
+def main() -> None:
+    args = parse_args()
+    gammas = [float(g) for g in args.gammas.split(",")]
+    out = {}
+
+    for gamma in gammas:
+        model = ct_lucas.scalar_lucas(gamma=gamma)
+        solver = load_solver(model, dt=0.1)
+        key = jax.random.PRNGKey(1)
+        loss = solver(jnp.ones((64,)) * 0.8, key)
+        out[gamma] = float(loss)
+
+    args.output.mkdir(exist_ok=True)
+    json.dump(out, open(args.output / "grid.json", "w"))
+    print("grid-search results", out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document `grid_search.py`
- allow passing gammas and output path via CLI
- reference the example script in the README

## Testing
- `SKIP=mypy pre-commit run --files README.md examples/grid_search.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578607227c833390aa96f68cc1f01a