### PR TITLE
Implement ND Poisson residual with tests

### DIFF
--- a/bsde_dsgE/__init__.py
+++ b/bsde_dsgE/__init__.py
@@ -5,14 +5,17 @@ imported here so users can simply ``import bsde_dsgE`` and access the KFAC
 helpers without remembering the submodule layout.
 """
 
+from .core.init import load_solver
 from .kfac import (
-    init_state as init_kfac_state,
-    kfac_update,
     KFACPINNSolver,
+    kfac_update,
     pinn_loss,
     poisson_1d_residual,
+    poisson_nd_residual,
 )
-from .core.init import load_solver
+from .kfac import (
+    init_state as init_kfac_state,
+)
 
 __all__ = [
     "kfac_update",
@@ -20,5 +23,6 @@ __all__ = [
     "KFACPINNSolver",
     "pinn_loss",
     "poisson_1d_residual",
+    "poisson_nd_residual",
     "load_solver",
 ]

--- a/bsde_dsgE/kfac/__init__.py
+++ b/bsde_dsgE/kfac/__init__.py
@@ -5,9 +5,9 @@ Curvature update along with a simple training loop for PINNs.  Additional
 helpers for common PDEs are provided for convenience.
 """
 
-from .optimizer import kfac_update, _init_state
+from .optimizer import _init_state, kfac_update
+from .pde import pinn_loss, poisson_1d_residual, poisson_nd_residual
 from .solver import KFACPINNSolver
-from .pde import poisson_1d_residual, pinn_loss
 
 # Public alias for the optimiser state initialiser
 init_state = _init_state
@@ -17,5 +17,6 @@ __all__ = [
     "kfac_update",
     "init_state",
     "poisson_1d_residual",
+    "poisson_nd_residual",
     "pinn_loss",
 ]

--- a/notebooks/kfac_pinn_2d_poisson.ipynb
+++ b/notebooks/kfac_pinn_2d_poisson.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8c38341c",
+   "metadata": {},
+   "source": [
+    "# 2-D Poisson with KFAC\n",
+    "This notebook shows `poisson_nd_residual`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f798bc4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jax, jax.numpy as jnp\n",
+    "import equinox as eqx\n",
+    "from bsde_dsgE.kfac import KFACPINNSolver, poisson_nd_residual\n",
+    "\n",
+    "net = eqx.nn.MLP(in_size=2, out_size=1, width_size=16, depth=2, key=jax.random.PRNGKey(0))\n",
+    "\n",
+    "def loss_fn(net, x):\n",
+    "    interior = x\n",
+    "    bc = jnp.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])\n",
+    "    res = poisson_nd_residual(lambda z: net(z).squeeze(), interior)\n",
+    "    bc_res = net(bc).squeeze()\n",
+    "    return jnp.mean(res ** 2) + jnp.mean(bc_res ** 2)\n",
+    "\n",
+    "solver = KFACPINNSolver(net=net, loss_fn=loss_fn, lr=1e-2, num_steps=10)\n",
+    "xs = jax.random.uniform(jax.random.PRNGKey(1), (16, 2))\n",
+    "losses = solver.run(xs, jax.random.PRNGKey(2))\n",
+    "print('final loss', float(losses[-1]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_pde.py
+++ b/tests/test_pde.py
@@ -1,17 +1,40 @@
 import jax.numpy as jnp
-from bsde_dsgE.kfac.pde import poisson_1d_residual, pinn_loss
+from bsde_dsgE.kfac.pde import (
+    pinn_loss,
+    poisson_1d_residual,
+    poisson_nd_residual,
+)
 
 
-def test_poisson_zero_residual():
-    net = lambda x: jnp.zeros_like(x)
+def test_poisson_zero_residual() -> None:
+    def net(x: jnp.ndarray) -> jnp.ndarray:
+        return jnp.zeros_like(x)
+
     x = jnp.linspace(0.0, 1.0, 4)
     res = poisson_1d_residual(net, x)
     assert jnp.allclose(res, 0)
 
 
-def test_pinn_loss_zero_solution():
-    net = lambda x: jnp.zeros_like(x)
+def test_pinn_loss_zero_solution() -> None:
+    def net(x: jnp.ndarray) -> jnp.ndarray:
+        return jnp.zeros_like(x)
+
     interior = jnp.linspace(0.0, 1.0, 4)
     bc = jnp.array([0.0, 1.0])
     loss = pinn_loss(net, interior, bc)
     assert loss == 0
+
+
+def test_poisson_nd_zero_residual() -> None:
+    def net(x: jnp.ndarray) -> float:
+        return 0.0
+
+    x = jnp.array(
+        [
+            [0.1, 0.2],
+            [0.3, 0.7],
+            [0.5, 0.5],
+        ]
+    )
+    res = poisson_nd_residual(net, x)
+    assert jnp.allclose(res, 0)


### PR DESCRIPTION
## Summary
- extend PDE utilities with `poisson_nd_residual`
- re-export the new helper in package `__init__`
- add tests for the n-D residual
- demonstrate usage in a new notebook

## Testing
- `pre-commit run --files bsde_dsgE/kfac/pde.py bsde_dsgE/kfac/__init__.py bsde_dsgE/__init__.py tests/test_pde.py notebooks/kfac_pinn_2d_poisson.ipynb`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578f00f6bc833393e981ef339cb255