### PR TITLE
Enable notebook docs build

### DIFF
--- a/bsde_dsgE/core/nets.py
+++ b/bsde_dsgE/core/nets.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 
 
-class ResNet(eqx.Module):  # type: ignore[misc]
+class ResNet(eqx.Module):
     """Simple residual-style network returning ``(y, z)``."""
 
     mlp: eqx.nn.MLP

--- a/bsde_dsgE/core/solver.py
+++ b/bsde_dsgE/core/solver.py
@@ -14,7 +14,7 @@ import jax.numpy as jnp
 __all__ = ["BSDEProblem", "Solver"]
 
 
-class BSDEProblem(eqx.Module):  # type: ignore[misc]
+class BSDEProblem(eqx.Module):
     drift: Callable[[jax.Array], jax.Array]
     diff: Callable[[jax.Array], jax.Array]
     generator: Callable[[jax.Array, jax.Array, jax.Array], jax.Array]
@@ -29,7 +29,7 @@ class BSDEProblem(eqx.Module):  # type: ignore[misc]
         return x + mu * dt + self.diff(x) * dW
 
 
-class Solver(eqx.Module):  # type: ignore[misc]
+class Solver(eqx.Module):
     net: Callable[[jax.Array, jax.Array], tuple[jax.Array, jax.Array]]
     problem: BSDEProblem
     dt: float

--- a/bsde_dsgE/kfac/optimizer.py
+++ b/bsde_dsgE/kfac/optimizer.py
@@ -54,7 +54,7 @@ def _init_state(params: Any) -> Any:
     return jax.tree_util.tree_map(lambda p: jnp.zeros_like(p), params)
 
 
-@eqx.filter_jit  # type: ignore[misc]
+@eqx.filter_jit
 def kfac_update(
     params: Any,
     grads: Any,

--- a/bsde_dsgE/kfac/solver.py
+++ b/bsde_dsgE/kfac/solver.py
@@ -32,7 +32,7 @@ import jax.numpy as jnp
 from .optimizer import _init_state, kfac_update
 
 
-class KFACPINNSolver(eqx.Module):  # type: ignore[misc]
+class KFACPINNSolver(eqx.Module):
     """Trainer for PINNs using a KFAC update.
 
     Parameters
@@ -77,7 +77,7 @@ class KFACPINNSolver(eqx.Module):  # type: ignore[misc]
         params, static = eqx.partition(self.net, eqx.is_array)
         fisher_state = _init_state(params)
 
-        @eqx.filter_jit  # type: ignore[misc]
+        @eqx.filter_jit
         def step(
             params: Any,
             fisher_state: Any,

--- a/ci/lint_test.yml
+++ b/ci/lint_test.yml
@@ -8,7 +8,8 @@ jobs:
     - uses: actions/setup-python@v5
       with: {python-version: '3.11'}
     - run: pip install jax jaxlib
-    - run: pip install .[dev]
+    - run: pip install .[dev,docs]
     - run: ruff check .
     - run: mypy bsde_dsgE
     - run: pytest -q
+    - run: sphinx-build -n -b html docs docs/_build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,15 @@ import sys
 sys.path.insert(0, os.path.abspath('..'))
 
 project = 'BSDE DSGE'
-extensions = ['myst_parser', 'sphinx.ext.autodoc', 'sphinx_autodoc_typehints']
+extensions = [
+    'myst_parser',
+    'sphinx.ext.autodoc',
+    'sphinx_autodoc_typehints',
+    'nbsphinx',
+]
+
+# Execute notebooks during the build so CI fails on execution errors
+nbsphinx_execute = 'always'
 source_suffix = {'.md': 'markdown'}
 master_doc = 'index'
 html_theme = 'alabaster'

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,15 @@
 # KFAC PINN Documentation
 
 This site collects minimal documentation for the `bsde_dsgE.kfac` utilities.
-For hands-on tutorials see the notebooks in the repository:
+The tutorial notebooks are rendered directly via ``nbsphinx``.
 
-- [kfac_demo.ipynb](../notebooks/kfac_demo.ipynb)
-- [kfac_toy_example.ipynb](../notebooks/kfac_toy_example.ipynb)
-- [kfac_pinn_quickstart.ipynb](../notebooks/kfac_pinn_quickstart.ipynb)
-- [kfac_pinn_pkg_quickstart.ipynb](../notebooks/kfac_pinn_pkg_quickstart.ipynb)
+.. toctree::
+   :maxdepth: 1
+
+   ../notebooks/kfac_demo.ipynb
+   ../notebooks/kfac_toy_example.ipynb
+   ../notebooks/kfac_pinn_quickstart.ipynb
+   ../notebooks/kfac_pinn_pkg_quickstart.ipynb
 
 These notebooks walk through defining a network, setting up
-`KFACPINNSolver` and running the optimisation loop.
+``KFACPINNSolver`` and running the optimisation loop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,13 @@ requires-python = ">=3.10"
 dependencies = ["jax>=0.4", "equinox>=0.11", "optax>=0.2", "scipy"]
 [project.optional-dependencies]
 gpu = ["jax[cuda12_pip]"]
-docs = ["myst-parser", "sphinx", "sphinx-autodoc-typehints"]
+docs = [
+  "myst-parser",
+  "sphinx",
+  "sphinx-autodoc-typehints",
+  "nbsphinx",
+  "jupyter",
+]
 dev  = ["pytest", "ruff", "black", "mypy", "pre-commit"]
 examples = ["dvc"]
 


### PR DESCRIPTION
## Summary
- add nbsphinx config so docs render notebooks
- list nbsphinx and jupyter in doc extras
- build docs during CI
- remove unused mypy ignores

## Testing
- `ruff check .`
- `mypy bsde_dsgE`
- `pytest -q`
- `sphinx-build -n -b html docs docs/_build/html`

------
https://chatgpt.com/codex/tasks/task_e_6857916eeffc8333b4c7ee4da725cb43