### PR TITLE
Add JupyterLab to dev extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Our aim: **from zero to publishable replication** in a weekend.
 * [Equinox](https://github.com/patrick-kidger/equinox)
 * [Optax](https://github.com/deepmind/optax)
 * [SciPy](https://scipy.org)
+* [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/) – required for the
+  tutorial notebooks
 
 ```bash
 # ⬇️ user install
@@ -60,6 +62,9 @@ pytest -q                     # 30 s smoke-tests
 
 The distribution on PyPI is named ``bsde-dsge`` while the Python package is
 imported as ``bsde_dsgE``.
+
+JupyterLab comes with the ``[dev]`` extras so that the tutorial notebooks run
+out of the box.
 
 ## 3\tKFAC for PINNs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ docs = [
   "nbsphinx",
   "jupyter",
 ]
-dev  = ["pytest", "ruff", "black", "mypy", "pre-commit"]
+dev  = ["pytest", "ruff", "black", "mypy", "pre-commit", "jupyterlab"]
 examples = ["dvc"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- include `jupyterlab` in the development optional dependencies
- note notebook requirements in the README Quick-start section

## Testing
- `pre-commit run --files pyproject.toml README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e3a1817c8333920a8bcb32094e2e