### PR TITLE
Add flexible boundary conditions to Poisson helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ examples:
 * [`grid_search.py`](examples/grid_search.py) – sweep risk aversion values
 * `pinn-demo` – command-line Poisson PINN demo
 
+The helper :func:`bsde_dsgE.kfac.pinn_loss` now accepts custom Dirichlet or
+Neumann boundary functions.  Pass ``dirichlet_bc`` or ``neumann_bc`` when
+constructing the loss to enforce non-zero conditions.
+
 See the generated documentation in [`docs/`](docs/) for a rendered version of
 these tutorials.
 

--- a/tests/test_pde.py
+++ b/tests/test_pde.py
@@ -25,6 +25,30 @@ def test_pinn_loss_zero_solution() -> None:
     assert loss == 0
 
 
+def test_poisson_dirichlet_bc() -> None:
+    net = lambda x: x**2
+    bc = jnp.array([0.0, 1.0])
+    res = poisson_1d_residual(net, bc, dirichlet_bc=lambda z: z**2)
+    assert jnp.allclose(res, 0)
+
+
+def test_poisson_neumann_bc() -> None:
+    net = lambda x: x**2
+    bc = jnp.array([0.0, 1.0])
+    res = poisson_1d_residual(net, bc, neumann_bc=lambda z: 2 * z)
+    assert jnp.allclose(res, 0)
+
+
+def test_pinn_loss_custom_bcs() -> None:
+    net = lambda x: jnp.zeros_like(x)
+    interior = jnp.linspace(0.0, 1.0, 4)
+    bc = jnp.array([0.0, 1.0])
+    loss_dir = pinn_loss(net, interior, bc, dirichlet_bc=lambda x: 0.0)
+    loss_neu = pinn_loss(net, interior, bc, neumann_bc=lambda x: 0.0)
+    assert loss_dir == 0
+    assert loss_neu == 0
+
+
 def test_poisson_nd_zero_residual() -> None:
     def net(x: jnp.ndarray) -> float:
         return 0.0


### PR DESCRIPTION
## Summary
- allow optional Dirichlet and Neumann boundary condition functions
- document boundary condition usage in README and docstrings
- expand PDE unit tests for the new boundary options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e681a8108333972977ea67f91cab