### PR TITLE
Add Poisson 2-D CLI demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ examples:
   – integrated module
 * [`grid_search.py`](examples/grid_search.py) – sweep risk aversion values
 * `pinn-demo` – command-line Poisson PINN demo
+* `pinn-poisson2d` – 2-D Poisson PINN demo
+
+```bash
+$ pinn-poisson2d
+final loss ...
+```
 
 The helper :func:`bsde_dsgE.kfac.pinn_loss` now accepts custom Dirichlet or
 Neumann boundary functions.  Pass ``dirichlet_bc`` or ``neumann_bc`` when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ examples = ["dvc"]
 
 [project.scripts]
 pinn-demo = "bsde_dsgE.cli:pinn_demo"
+pinn-poisson2d = "bsde_dsgE.cli:pinn_poisson2d"
 
 [tool.hatch.build.targets.wheel]
 packages = ["bsde_dsgE"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,13 @@
-from bsde_dsgE.cli import pinn_demo
+from bsde_dsgE.cli import pinn_demo, pinn_poisson2d
 
 
 def test_pinn_demo_runs(capsys):
     pinn_demo()
+    out = capsys.readouterr().out
+    assert "final loss" in out
+
+
+def test_pinn_poisson2d_runs(capsys):
+    pinn_poisson2d()
     out = capsys.readouterr().out
     assert "final loss" in out


### PR DESCRIPTION
## Summary
- add `pinn_poisson2d` command-line demo
- register new CLI entry point
- show example usage in README
- test new command in the regression suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e7fc84f8833391683f0f932c2655