### PR TITLE
Move tooling config to setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,3 @@ pinn-poisson2d = "bsde_dsgE.cli:pinn_poisson2d"
 [tool.hatch.build.targets.wheel]
 packages = ["bsde_dsgE"]
 
-[tool.ruff]
-src = ["bsde_dsgE"]
-
-[tool.ruff.lint]
-select = ["E", "F", "I", "B"]
-
-[tool.mypy]
-python_version = "3.11"
-strict = true
-files = "bsde_dsgE"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[tool:ruff]
+src = bsde_dsgE
+
+[tool:ruff.lint]
+select = E, F, I, B
+
+[mypy]
+python_version = 3.11
+strict = true
+files = bsde_dsgE

--- a/tests/test_setup_cfg.py
+++ b/tests/test_setup_cfg.py
@@ -1,0 +1,22 @@
+"""Tests for project configuration."""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+
+def test_setup_cfg_has_tool_settings() -> None:
+    cfg_path = Path(__file__).resolve().parents[1] / "setup.cfg"
+    assert cfg_path.exists(), "setup.cfg missing"
+
+    parser = configparser.ConfigParser()
+    parser.read(cfg_path)
+
+    assert parser["tool:ruff"]["src"] == "bsde_dsgE"
+    assert parser["tool:ruff.lint"]["select"] == "E, F, I, B"
+
+    assert parser["mypy"]["python_version"] == "3.11"
+    assert parser.getboolean("mypy", "strict")
+    assert parser["mypy"]["files"] == "bsde_dsgE"
+


### PR DESCRIPTION
## Summary
- migrate Ruff and mypy settings from `pyproject.toml` into `setup.cfg`
- add a unit test to ensure the new config file contains expected values

## Testing
- `ruff check tests/test_setup_cfg.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857ff2004608333b1c297d25cfbae31