### PR TITLE
Fix Ruff config sections

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
-[tool:ruff]
+[tool.ruff]
 src = bsde_dsgE
 
-[tool:ruff.lint]
+[tool.ruff.lint]
 select = E, F, I, B
 
 [mypy]

--- a/tests/test_setup_cfg.py
+++ b/tests/test_setup_cfg.py
@@ -13,8 +13,8 @@ def test_setup_cfg_has_tool_settings() -> None:
     parser = configparser.ConfigParser()
     parser.read(cfg_path)
 
-    assert parser["tool:ruff"]["src"] == "bsde_dsgE"
-    assert parser["tool:ruff.lint"]["select"] == "E, F, I, B"
+    assert parser["tool.ruff"]["src"] == "bsde_dsgE"
+    assert parser["tool.ruff.lint"]["select"] == "E, F, I, B"
 
     assert parser["mypy"]["python_version"] == "3.11"
     assert parser.getboolean("mypy", "strict")


### PR DESCRIPTION
## Summary
- update ruff config headers to `[tool.ruff]` and `[tool.ruff.lint]`
- update tests for new ruff config

## Testing
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68581f320b9483339cf836567e9a70ee