### PR TITLE
Track dividend draws with DVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .pytest_cache/
 bsde_seed.egg-info/
+data/dividend_draws.csv

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Sample Lucas dividend draws are stored in ``data/dividend_draws.csv`` and
 tracked with `dvc`.  After cloning the repository, run
 
 ```bash
-dvc pull
+dvc pull data/dividend_draws.csv.dvc
 ```
 
 to fetch the CSV file.

--- a/data/dividend_draws.csv.dvc
+++ b/data/dividend_draws.csv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 6a1b768d164466ae6502cd673b5d109c
+  size: 38
+  hash: md5
+  path: dividend_draws.csv

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,5 +1,0 @@
-stages:
-  prepare_data:
-    cmd: python scripts/generate_dividend_draws.py
-    outs:
-      - data/dividend_draws.csv

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,13 +1,19 @@
 from pathlib import Path
-import yaml
 
 from scripts.generate_dividend_draws import main as generate
 
 
-def test_dvc_stage():
-    spec = yaml.safe_load(Path("dvc.yaml").read_text())
-    assert "prepare_data" in spec["stages"]
-    assert spec["stages"]["prepare_data"]["outs"] == ["data/dividend_draws.csv"]
+def test_csv_dvc_exists() -> None:
+    dvc_file = Path("data/dividend_draws.csv.dvc")
+    assert dvc_file.exists(), ".dvc file missing"
+
+    text = dvc_file.read_text().splitlines()[0]
+    assert text.strip() == "outs:", ".dvc file format unexpected"
+
+
+def test_readme_dvc_pull() -> None:
+    readme = Path("README.md").read_text()
+    assert "dvc pull data/dividend_draws.csv.dvc" in readme
 
 
 def test_generate_dividend_draws(tmp_path):


### PR DESCRIPTION
## Summary
- generate dividend draw CSV and track it with DVC
- ignore generated CSV in git
- mention how to pull data in README
- update tests for DVC tracking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685822015c8483338c9b8da449f74b4f