### PR TITLE
Add fetch-data DVC stage and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,14 @@ out of the box.
 ### 2.2\tData
 
 Sample Lucas dividend draws are stored in ``data/dividend_draws.csv`` and
-tracked with `dvc`.  After cloning the repository, run
+tracked with `dvc`. After cloning the repository, run
 
 ```bash
-dvc pull data/dividend_draws.csv.dvc
+dvc repro fetch-data
 ```
 
-to fetch the CSV file.
+to fetch the CSV file using the ``fetch-data`` stage defined in
+``dvc.yaml``.
 
 ## 3\tKFAC for PINNs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,4 +13,5 @@ This site collects minimal documentation for the `bsde_dsgE.kfac` utilities. The
 
 These notebooks walk through defining a network, setting up ``KFACPINNSolver`` and running the optimisation loop.
 
-The repository includes a small CSV dataset `data/dividend_draws.csv` tracked with `dvc`. Run ``dvc pull`` after cloning to fetch the file.
+The repository includes a small CSV dataset `data/dividend_draws.csv` tracked with
+`dvc`. Run ``dvc repro fetch-data`` after cloning to fetch the file.

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,7 @@
+stages:
+  fetch-data:
+    cmd: dvc pull data/dividend_draws.csv.dvc
+    deps:
+      - data/dividend_draws.csv.dvc
+    outs:
+      - data/dividend_draws.csv

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -11,12 +11,22 @@ def test_csv_dvc_exists() -> None:
     assert text.strip() == "outs:", ".dvc file format unexpected"
 
 
-def test_readme_dvc_pull() -> None:
+def test_readme_dvc_repro() -> None:
     readme = Path("README.md").read_text()
-    assert "dvc pull data/dividend_draws.csv.dvc" in readme
+    assert "dvc repro fetch-data" in readme
 
 
-def test_generate_dividend_draws(tmp_path):
+def test_dvc_yaml_stage_exists() -> None:
+    dvc_yaml = Path("dvc.yaml")
+    assert dvc_yaml.exists(), "dvc.yaml missing"
+    text = dvc_yaml.read_text()
+    assert "fetch-data:" in text, "fetch-data stage missing"
+    assert "data/dividend_draws.csv.dvc" in text, "dependency missing"
+    assert "data/dividend_draws.csv" in text, "output missing"
+    assert "cmd: dvc pull data/dividend_draws.csv.dvc" in text
+
+
+def test_generate_dividend_draws(tmp_path: Path) -> None:
     out_file = tmp_path / "dividend_draws.csv"
     generate(out_file)
     text = out_file.read_text().strip().splitlines()


### PR DESCRIPTION
## Summary
- introduce a `dvc.yaml` pipeline with a `fetch-data` stage
- update README and docs to instruct running `dvc repro fetch-data`
- expand tests to cover new DVC stage and documentation

## Testing
- `pre-commit run --files README.md docs/index.md tests/test_data.py dvc.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582b6e859483338f72627be5458393