### PR TITLE
Introduce NOTEBOOK_FAST to speed notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ examples:
 * `pinn-demo` – command-line Poisson PINN demo
 * `pinn-poisson2d` – 2-D Poisson PINN demo
 
+Set the environment variable ``NOTEBOOK_FAST=1`` to run these examples with
+smaller grids and fewer training steps. Continuous integration uses this
+flag to keep runtimes short.
+
 ```bash
 $ pinn-poisson2d
 final loss ...

--- a/ci/lint_test.yml
+++ b/ci/lint_test.yml
@@ -12,4 +12,6 @@ jobs:
     - run: ruff check .
     - run: mypy bsde_dsgE
     - run: pytest -q
+      env:
+        NOTEBOOK_FAST: '1'
     - run: sphinx-build -n -b html docs docs/_build/html

--- a/examples/grid_search.py
+++ b/examples/grid_search.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import pathlib
 
 import jax
@@ -40,6 +41,8 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     gammas = [float(g) for g in args.gammas.split(",")]
+    if os.environ.get("NOTEBOOK_FAST"):
+        gammas = gammas[:1]
     out = {}
 
     for gamma in gammas:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,47 @@
-from bsde_dsgE.cli import pinn_demo, pinn_poisson2d
+import jax.numpy as jnp
+
+from bsde_dsgE import cli
 
 
 def test_pinn_demo_runs(capsys):
-    pinn_demo()
+    cli.pinn_demo()
     out = capsys.readouterr().out
     assert "final loss" in out
 
 
 def test_pinn_poisson2d_runs(capsys):
-    pinn_poisson2d()
+    cli.pinn_poisson2d()
     out = capsys.readouterr().out
     assert "final loss" in out
+
+
+def test_pinn_demo_fast_env(monkeypatch):
+    captured = {}
+
+    class DummySolver:
+        def __init__(self, *args, num_steps: int, **kwargs):
+            captured["steps"] = num_steps
+
+        def run(self, xs, key):
+            return jnp.zeros(captured["steps"])
+
+    monkeypatch.setattr(cli, "KFACPINNSolver", DummySolver)
+    monkeypatch.setenv("NOTEBOOK_FAST", "1")
+    cli.pinn_demo()
+    assert captured["steps"] == 3
+
+
+def test_pinn_poisson2d_fast_env(monkeypatch):
+    captured = {}
+
+    class DummySolver:
+        def __init__(self, *args, num_steps: int, **kwargs):
+            captured["steps"] = num_steps
+
+        def run(self, xs, key):
+            return jnp.zeros(captured["steps"])
+
+    monkeypatch.setattr(cli, "KFACPINNSolver", DummySolver)
+    monkeypatch.setenv("NOTEBOOK_FAST", "1")
+    cli.pinn_poisson2d()
+    assert captured["steps"] == 3

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,26 @@
+import json
+from types import SimpleNamespace
+
+import jax.numpy as jnp
+
+from examples import grid_search
+
+
+def test_grid_search_fast(monkeypatch, tmp_path):
+    args = SimpleNamespace(gammas="1,2,3", output=tmp_path)
+    monkeypatch.setattr(grid_search, "parse_args", lambda: args)
+
+    monkeypatch.setattr(grid_search.ct_lucas, "scalar_lucas", lambda gamma: None)
+
+    def dummy_load_solver(model, dt):
+        def solver(x, key):
+            return jnp.array(0.0)
+
+        return solver
+
+    monkeypatch.setattr(grid_search, "load_solver", dummy_load_solver)
+    monkeypatch.setenv("NOTEBOOK_FAST", "1")
+    grid_search.main()
+
+    data = json.load(open(tmp_path / "grid.json"))
+    assert len(data) == 1


### PR DESCRIPTION
## Summary
- let CLI demos and grid search respect `NOTEBOOK_FAST`
- document `NOTEBOOK_FAST` usage
- use `NOTEBOOK_FAST=1` in CI
- add regression tests for fast mode

## Testing
- `ruff check .` *(fails: Found 9 errors)*
- `mypy bsde_dsgE`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582dc34bb8833399594bac35cca4d4