### PR TITLE
Add grid search output test

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -24,3 +24,23 @@ def test_grid_search_fast(monkeypatch, tmp_path):
 
     data = json.load(open(tmp_path / "grid.json"))
     assert len(data) == 1
+
+
+def test_grid_search_outputs(monkeypatch, tmp_path):
+    args = SimpleNamespace(gammas="1,2,3", output=tmp_path)
+    monkeypatch.setattr(grid_search, "parse_args", lambda: args)
+
+    monkeypatch.setattr(grid_search.ct_lucas, "scalar_lucas", lambda gamma: None)
+
+    def dummy_load_solver(model, dt):
+        def solver(x, key):
+            return jnp.array(0.0)
+
+        return solver
+
+    monkeypatch.setattr(grid_search, "load_solver", dummy_load_solver)
+
+    grid_search.main()
+
+    data = json.load(open(tmp_path / "grid.json"))
+    assert set(data.keys()) == {"1.0", "2.0", "3.0"}


### PR DESCRIPTION
## Summary
- check expected gamma keys in grid search output

## Testing
- `pytest tests/test_examples.py::test_grid_search_fast -q`
- `pytest tests/test_examples.py::test_grid_search_outputs -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858335c29f883338a678eb12184b7e7