### PR TITLE
Refactor Ruff settings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
 [tool.ruff]
 src = bsde_dsgE
-
-[tool.ruff.lint]
 select = E, F, I, B
 
 [mypy]

--- a/tests/test_setup_cfg.py
+++ b/tests/test_setup_cfg.py
@@ -14,7 +14,7 @@ def test_setup_cfg_has_tool_settings() -> None:
     parser.read(cfg_path)
 
     assert parser["tool.ruff"]["src"] == "bsde_dsgE"
-    assert parser["tool.ruff.lint"]["select"] == "E, F, I, B"
+    assert parser["tool.ruff"]["select"] == "E, F, I, B"
 
     assert parser["mypy"]["python_version"] == "3.11"
     assert parser.getboolean("mypy", "strict")


### PR DESCRIPTION
## Summary
- configure Ruff lint options directly in `[tool.ruff]`
- update tests for the new configuration

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68583959d0808333915c4f7918d3cd71