### PR TITLE
Fix ruff section headers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [tool.ruff]
 src = bsde_dsgE
+
+[tool.ruff.lint]
 select = E, F, I, B
 
 [mypy]

--- a/tests/test_setup_cfg.py
+++ b/tests/test_setup_cfg.py
@@ -14,7 +14,7 @@ def test_setup_cfg_has_tool_settings() -> None:
     parser.read(cfg_path)
 
     assert parser["tool.ruff"]["src"] == "bsde_dsgE"
-    assert parser["tool.ruff"]["select"] == "E, F, I, B"
+    assert parser["tool.ruff.lint"]["select"] == "E, F, I, B"
 
     assert parser["mypy"]["python_version"] == "3.11"
     assert parser.getboolean("mypy", "strict")


### PR DESCRIPTION
## Summary
- add `[tool.ruff.lint]` section to hold lint options
- adjust config test for new section
- run `ruff check .` to show lint paths

## Testing
- `pytest -q tests/test_setup_cfg.py::test_setup_cfg_has_tool_settings -q`
- `ruff check . | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_685855c00f188333890b9cf88de6603a