### PR TITLE
Update Ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,11 @@ pinn-poisson2d = "bsde_dsgE.cli:pinn_poisson2d"
 [tool.hatch.build.targets.wheel]
 packages = ["bsde_dsgE"]
 
+[tool.ruff]
+src = ["bsde_dsgE"]
+exclude = ["notebooks/**"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]
+ignore = ["E401", "E731", "I001", "E501"]
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,10 @@
 [tool.ruff]
 src = bsde_dsgE
+exclude = ["notebooks/**"]
 
 [tool.ruff.lint]
 select = E, F, I, B
+ignore = ["E401", "E731", "I001", "E501"]
 
 [mypy]
 python_version = 3.11

--- a/tests/test_setup_cfg.py
+++ b/tests/test_setup_cfg.py
@@ -14,7 +14,9 @@ def test_setup_cfg_has_tool_settings() -> None:
     parser.read(cfg_path)
 
     assert parser["tool.ruff"]["src"] == "bsde_dsgE"
+    assert parser["tool.ruff"]["exclude"] == '["notebooks/**"]'
     assert parser["tool.ruff.lint"]["select"] == "E, F, I, B"
+    assert parser["tool.ruff.lint"]["ignore"] == '["E401", "E731", "I001", "E501"]'
 
     assert parser["mypy"]["python_version"] == "3.11"
     assert parser.getboolean("mypy", "strict")


### PR DESCRIPTION
## Summary
- configure Ruff in `setup.cfg` and `pyproject.toml`
- update unit test for new Ruff settings

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685859bdc1708333b3e984e65b1a42a9