### PR TITLE
Add sphinx to dev extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ docs = [
   "nbsphinx",
   "jupyter",
 ]
-dev  = ["pytest", "ruff", "black", "mypy", "pre-commit", "jupyterlab"]
+dev  = ["pytest", "ruff", "black", "mypy", "pre-commit", "jupyterlab", "sphinx"]
 
 [project.scripts]
 pinn-demo = "bsde_dsgE.cli:pinn_demo"

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import tomllib
+
+
+def test_dev_optional_dependencies_include_sphinx() -> None:
+    pyproject = Path("pyproject.toml")
+    assert pyproject.exists(), "pyproject.toml missing"
+    data = tomllib.loads(pyproject.read_text())
+    dev_deps = data["project"]["optional-dependencies"]["dev"]
+    assert "sphinx" in dev_deps, "'sphinx' not found in dev optional dependencies"
+


### PR DESCRIPTION
## Summary
- include sphinx in the dev optional dependencies
- test that dev optional dependencies contain sphinx

## Testing
- `pytest -q`
- `pip install .[dev]`
- `pip install .[docs]`
- `sphinx-build -n -b html docs docs/_build/html`

------
https://chatgpt.com/codex/tasks/task_e_68585ec3156c83339a5c142da99e4868