### PR TITLE
Move ruff config fully to setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,3 @@ pinn-poisson2d = "bsde_dsgE.cli:pinn_poisson2d"
 
 [tool.hatch.build.targets.wheel]
 packages = ["bsde_dsgE"]
-
-[tool.ruff]
-src = ["bsde_dsgE"]
-exclude = ["notebooks/**"]
-
-[tool.ruff.lint]
-select = ["E", "F", "I", "B"]
-ignore = ["E401", "E731", "I001", "E501"]
-

--- a/tests/test_setup_cfg.py
+++ b/tests/test_setup_cfg.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import configparser
+import tomllib
 from pathlib import Path
 
 
@@ -21,4 +22,12 @@ def test_setup_cfg_has_tool_settings() -> None:
     assert parser["mypy"]["python_version"] == "3.11"
     assert parser.getboolean("mypy", "strict")
     assert parser["mypy"]["files"] == "bsde_dsgE"
+
+
+def test_pyproject_has_no_ruff_settings() -> None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    assert pyproject_path.exists(), "pyproject.toml missing"
+
+    data = tomllib.loads(pyproject_path.read_text())
+    assert "tool" not in data or "ruff" not in data.get("tool", {})
 


### PR DESCRIPTION
## Summary
- remove ruff configuration from `pyproject.toml`
- verify ruff config remains in `setup.cfg`
- test that `pyproject.toml` has no ruff configuration

## Testing
- `pre-commit run --files pyproject.toml setup.cfg`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858618a11a083338bbceeb6c6961519