### PR TITLE
Add py.typed to package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,4 @@ pinn-poisson2d = "bsde_dsgE.cli:pinn_poisson2d"
 
 [tool.hatch.build.targets.wheel]
 packages = ["bsde_dsgE"]
+include = ["bsde_dsgE/py.typed"]

--- a/tests/test_pyproject.py
+++ b/tests/test_pyproject.py
@@ -9,3 +9,23 @@ def test_dev_optional_dependencies_include_sphinx() -> None:
     dev_deps = data["project"]["optional-dependencies"]["dev"]
     assert "sphinx" in dev_deps, "'sphinx' not found in dev optional dependencies"
 
+
+def test_wheel_includes_py_typed() -> None:
+    pyproject = Path("pyproject.toml")
+    assert pyproject.exists(), "pyproject.toml missing"
+    data = tomllib.loads(pyproject.read_text())
+    wheel_cfg = (
+        data
+        .get("tool", {})
+        .get("hatch", {})
+        .get("build", {})
+        .get("targets", {})
+        .get("wheel", {})
+    )
+    include = wheel_cfg.get("include", [])
+    assert "bsde_dsgE/py.typed" in include
+
+
+def test_py_typed_file_exists() -> None:
+    assert Path("bsde_dsgE/py.typed").exists()
+


### PR DESCRIPTION
## Summary
- include an empty `py.typed` file in the package
- add the file to package data in `pyproject.toml`
- test that the file exists and that the build configuration includes it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685866bb28cc833388ada229fe66b4d8